### PR TITLE
Update printed list after queued labels

### DIFF
--- a/bl_api_print_agent.py
+++ b/bl_api_print_agent.py
@@ -395,6 +395,7 @@ if __name__ == "__main__":
                 try:
                     print_label(item["label_data"], item.get("ext", "pdf"), item["order_id"])
                     mark_as_printed(item["order_id"])
+                    printed[item["order_id"]] = datetime.now()
                     send_messenger_message(item.get("last_order_data", {}))
                 except Exception as e:
                     logger.error(f"Błąd przetwarzania z kolejki: {e}")


### PR DESCRIPTION
## Summary
- update the `printed` cache after printing queued labels to skip them when fetching new orders

## Testing
- `python3 -m py_compile bl_api_print_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68497250b6d0832aaea7212e43dd1787