### PR TITLE
Rename ensure_printed_file to ensure_db_init

### DIFF
--- a/bl_api_print_agent.py
+++ b/bl_api_print_agent.py
@@ -98,7 +98,7 @@ def ensure_db():
             conn.commit()
     conn.close()
 
-def ensure_printed_file():
+def ensure_db_init():
     ensure_db()
 
 def load_printed_orders():
@@ -381,7 +381,7 @@ if __name__ == "__main__":
     logger.info(
         "[START] Agent BaseLinker z automatycznym getLabel + Messenger + dotenv"
     )
-    ensure_printed_file()
+    ensure_db_init()
     if ENABLE_HTTP_SERVER:
         threading.Thread(target=start_http_server, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- rename `ensure_printed_file()` to `ensure_db_init()`
- update call site in main function

## Testing
- `python3 -m py_compile bl_api_print_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_684975e85d7c832a8c6d3f2f773e09b8