### PR TITLE
Fix HTML escaping for history table

### DIFF
--- a/bl_api_print_agent.py
+++ b/bl_api_print_agent.py
@@ -11,6 +11,7 @@ import threading
 import http.server
 import socketserver
 import sqlite3
+import html
 from dotenv import load_dotenv
 
 # === WCZYTAJ Z .env ===
@@ -377,10 +378,12 @@ class AgentRequestHandler(http.server.BaseHTTPRequestHandler):
             printed = load_printed_orders()
             queue = load_queue()
             rows = "".join(
-                f"<tr><td>{oid}</td><td>{ts}</td></tr>" for oid, ts in sorted(printed.items())
+                f"<tr><td>{html.escape(str(oid))}</td><td>{html.escape(str(ts))}</td></tr>"
+                for oid, ts in sorted(printed.items())
             )
             qrows = "".join(
-                f"<tr><td>{item.get('order_id')}</td><td>W kolejce</td></tr>" for item in queue
+                f"<tr><td>{html.escape(str(item.get('order_id')))}</td><td>W kolejce</td></tr>"
+                for item in queue
             )
             table_html = (
                 "<table><tr><th>ID zamówienia</th><th>Czas</th></tr>" + rows + qrows + "</table>"


### PR DESCRIPTION
## Summary
- properly escape HTML for order history

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849994f1728832a9fc394489818d054