### PR TITLE
Implement 404 error branch in HTTP handler

### DIFF
--- a/bl_api_print_agent.py
+++ b/bl_api_print_agent.py
@@ -402,12 +402,21 @@ class AgentRequestHandler(http.server.BaseHTTPRequestHandler):
             except Exception as e:
                 log_html = f"<p>Błąd czytania logów: {e}</p>"
             self._send(render_page("Logi", log_html))
-        else:
+        elif self.path == "/":
             body = "<p>Wybierz opcję z menu powyżej.</p>"
             self._send(render_page("BaseLinker Print Agent", body))
+        else:
+            self.send_error(404, "Nie znaleziono strony")
 
     def log_message(self, format, *args):
         return
+
+    def send_error(self, code, message=None, explain=None):
+        if code == 404:
+            body = "<p>Nie znaleziono strony.</p>"
+            self._send(render_page("404 - Not Found", body), status=404)
+        else:
+            super().send_error(code, message, explain)
 
 def start_http_server():
     with socketserver.TCPServer(("", HTTP_PORT), AgentRequestHandler) as httpd:


### PR DESCRIPTION
## Summary
- return the main page only for `/`
- add a new fallback branch that triggers `send_error(404)`
- render custom 404 page via `send_error` override

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499b090ef4832aa61745457ab169db